### PR TITLE
Use SERVICE_DESTINATION as the default location of EXTRA_COMPOSE_FILE

### DIFF
--- a/bin/homecloud-service.sh
+++ b/bin/homecloud-service.sh
@@ -105,7 +105,7 @@ if [ -n "${ADDITIONAL_COMPOSE_FILE}" ]; then
 fi
 
 if [ -n "${EXTRA_COMPOSE_FILE}" ]; then
-    PROFILES=" -f ${EXTRA_COMPOSE_FILE} ${PROFILES}"
+    PROFILES=" -f ${SERVICE_DESTINATION}/${EXTRA_COMPOSE_FILE} ${PROFILES}"
 fi
 
 DOCKER_CMD=$(which docker||true)


### PR DESCRIPTION
Fix #15 